### PR TITLE
Typographer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Empty content no longer causes a null pointer exception in the sectionize rule
+- Typographer content appearing prior to a footnote in an inline block is now appropriately replaced
 
 ## [1.0.1] - 2025-04-08
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@ Each "new thought" and second-level heading automatically gets a section break a
 
 ## Sidenotes and Marginalia
 
-Here's where things really get exciting. Markdown footnotes[^foots] are a convenient way to move digressions and asides out of the primary flow of a document, but shoving them to the bottom of a long page is no good, either.
+Here's where things really get exciting... Markdown footnotes[^foots] are a convenient way to move digressions and asides out of the primary flow of a document---but shoving them to the bottom of a long page is no good, either.
 
 [^foots]: [Footnotes](https://www.markdownguide.org/extended-syntax#footnotes) weren't actually part of the original markdown spec, but they've become a popular bolt-on.
 
@@ -74,7 +74,7 @@ A full-width image can be achieved with the `.fullwidth` class on the figure tag
       inputText.onchange = handleChange
       function handleChange(e) {
         const text = window
-          .markdownit()
+          .markdownit({ typographer: true })
           .use(window.markdownitTufte)
           .use(window.markdownItAttrs)
           .render(e.target.value)

--- a/src/rules/sidenote.ts
+++ b/src/rules/sidenote.ts
@@ -279,6 +279,11 @@ export default function footnote_plugin(md: MarkdownIt) {
 
           const newInline = new state.Token("inline", "", 0)
           newInline.children = token.children.splice(0, refIdx + 1)
+          newInline.content = newInline.children.reduce(
+            (acc, { content }) => acc + content,
+            ""
+          )
+          token.content = token.children.reduce((acc, { content }) => acc + content, "")
           const openSpan = new state.Token("span_open", "span", 1)
           openSpan.attrSet("class", margin ? "marginnote" : "sidenote")
 

--- a/tests/fixtures/sidenote.md
+++ b/tests/fixtures/sidenote.md
@@ -1,13 +1,13 @@
 Creates a standard side-note
 .
-Edward Tufte popularized moving footnotes[^1] into the margin next to the relevant text.
+Edward Tufte popularized moving "footnotes"[^1] into the margin---next to the relevant text.
 
 [^1]: Comments and asides... that are tangential to the flow of the primary document.
 
 Here is an entirely separate paragraph.
 .
 <section>
-<p>Edward Tufte popularized moving footnotes<label for="sn-1" class="margin-toggle sidenote-number"></label><input id="sn-1" type="checkbox" class="margin-toggle"><span class="sidenote">Comments and asides… that are tangential to the flow of the primary document.</span> into the margin next to the relevant text.</p>
+<p>Edward Tufte popularized moving “footnotes”<label for="sn-1" class="margin-toggle sidenote-number"></label><input id="sn-1" type="checkbox" class="margin-toggle"><span class="sidenote">Comments and asides… that are tangential to the flow of the primary document.</span> into the margin—next to the relevant text.</p>
 <p>Here is an entirely separate paragraph.</p>
 </section>
 ..


### PR DESCRIPTION
Any typographic replacements (e.g. em-dashes, ellipses) appearing before a footnote in a single inline token are not getting replaced by the typographer extension. This code change fixes the issue by ensuring that the `content` field of each generated token matches its `children`.